### PR TITLE
Add env command to set up your shell per env

### DIFF
--- a/cmd/env.go
+++ b/cmd/env.go
@@ -27,10 +27,12 @@ var EnvCmd = &cobra.Command{
 			Kubeconfigs: kubeconfigs,
 			KubeDir:     kubeDir,
 		}
-		output, err := truss.Env(input)
+		environmentVars, err := truss.Env(input)
 		if err != nil {
 			return err
 		}
+
+		output := environmentVars.BashFormat(env)
 
 		fmt.Fprintln(cmd.OutOrStdout(), output)
 		return nil

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/instructure-bridge/truss-cli/truss"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// EnvCmd represents the env command
+var EnvCmd = &cobra.Command{
+	Use:   "env",
+	Short: "Display the commands to set up the shell environment for truss",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		env, err := cmd.Flags().GetString("env")
+		if err != nil {
+			return err
+		}
+		kubeconfigs := viper.GetStringMap("environments")
+		kubeDir, err := getKubeDir()
+		if err != nil {
+			return err
+		}
+		input := &truss.EnvInput{
+			Env:         env,
+			Kubeconfigs: kubeconfigs,
+			KubeDir:     kubeDir,
+		}
+		output, err := truss.Env(input)
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintln(cmd.OutOrStdout(), output)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(EnvCmd)
+}

--- a/cmd/env_test.go
+++ b/cmd/env_test.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"github.com/spf13/viper"
+)
+
+func TestEnv(t *testing.T) {
+	Convey("env", t, func() {
+		viper.Reset()
+
+		Convey("returns env for a valid environment", func() {
+			viper.Set("environments", map[string]interface{}{
+				"edge-cmh": "kubeconfig-truss-nonprod-cmh",
+			})
+
+			cmd := rootCmd
+			buff := bytes.NewBufferString("")
+			cmd.SetOut(buff)
+			cmd.SetArgs([]string{
+				"env",
+				"-e",
+				"edge-cmh",
+			})
+			cmd.Execute()
+			out, _ := ioutil.ReadAll(buff)
+			So(string(out), ShouldEqual, "export KUBECONFIG=/Users/jblanchard/.kube/kubeconfig-truss-nonprod-cmh\n# Run this command to configure your shell:\n# eval \"$(truss env -e edge-cmh)\"\n")
+		})
+
+		Convey("returns error for invalid environment", func() {
+			viper.Set("environments", map[string]interface{}{
+				"edge-cmh": "kubeconfig-truss-nonprod-cmh",
+			})
+
+			cmd := rootCmd
+			buff := bytes.NewBufferString("")
+			cmd.SetOut(buff)
+			cmd.SetArgs([]string{
+				"env",
+				"-e",
+				"no-env",
+			})
+			cmd.Execute()
+			out, _ := ioutil.ReadAll(buff)
+			So(string(out), ShouldContainSubstring, "Error: No kubeconfig found for env no-env")
+		})
+	})
+}

--- a/cmd/env_test.go
+++ b/cmd/env_test.go
@@ -12,6 +12,7 @@ import (
 func TestEnv(t *testing.T) {
 	Convey("env", t, func() {
 		viper.Reset()
+		viper.Set("kubeconfigfiles.directory", "/tmp/")
 
 		Convey("returns env for a valid environment", func() {
 			viper.Set("environments", map[string]interface{}{
@@ -28,7 +29,7 @@ func TestEnv(t *testing.T) {
 			})
 			cmd.Execute()
 			out, _ := ioutil.ReadAll(buff)
-			So(string(out), ShouldEqual, "export KUBECONFIG=/Users/jblanchard/.kube/kubeconfig-truss-nonprod-cmh\n# Run this command to configure your shell:\n# eval \"$(truss env -e edge-cmh)\"\n")
+			So(string(out), ShouldEqual, "export KUBECONFIG=/tmp/kubeconfig-truss-nonprod-cmh\n# Run this command to configure your shell:\n# eval \"$(truss env -e edge-cmh)\"\n")
 		})
 
 		Convey("returns error for invalid environment", func() {

--- a/truss/env.go
+++ b/truss/env.go
@@ -12,19 +12,34 @@ type EnvInput struct {
 	KubeDir     string
 }
 
-// Env returns string to eval that configures shell environment variables
-func Env(input *EnvInput) (string, error) {
-	buffer := bytes.NewBuffer(make([]byte, 0))
+// EnvironmentVars key/value pairs of environment variables that should be set in the shell
+type EnvironmentVars struct {
+	Kubeconfig string
+}
+
+// Env configures environment variables that should be set in the bash shell
+func Env(input *EnvInput) (EnvironmentVars, error) {
 	kubeconfigName := input.Kubeconfigs[input.Env]
 
 	if kubeconfigName == nil {
-		return "", fmt.Errorf("No kubeconfig found for env %s", input.Env)
+		return EnvironmentVars{}, fmt.Errorf("No kubeconfig found for env %s", input.Env)
 	}
 
 	kubeconfig := fmt.Sprintf("%s%s", input.KubeDir, kubeconfigName)
-	buffer.WriteString(fmt.Sprintf("export KUBECONFIG=%s\n", kubeconfig))
-	buffer.WriteString("# Run this command to configure your shell:\n")
-	buffer.WriteString(fmt.Sprintf("# eval \"$(truss env -e %s)\"", input.Env))
 
-	return buffer.String(), nil
+	environmentVars := EnvironmentVars{
+		Kubeconfig: kubeconfig,
+	}
+
+	return environmentVars, nil
+}
+
+// BashFormat formats environment variables for bash
+func (environmentVars *EnvironmentVars) BashFormat(env string) string {
+	buffer := bytes.NewBufferString("")
+	buffer.WriteString(fmt.Sprintf("export KUBECONFIG=%s\n", environmentVars.Kubeconfig))
+	buffer.WriteString("# Run this command to configure your shell:\n")
+	buffer.WriteString(fmt.Sprintf("# eval \"$(truss env -e %s)\"", env))
+
+	return buffer.String()
 }

--- a/truss/env.go
+++ b/truss/env.go
@@ -1,0 +1,30 @@
+package truss
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// EnvInput input
+type EnvInput struct {
+	Env         string
+	Kubeconfigs map[string]interface{}
+	KubeDir     string
+}
+
+// Env returns string to eval that configures shell environment variables
+func Env(input *EnvInput) (string, error) {
+	buffer := bytes.NewBuffer(make([]byte, 0))
+	kubeconfigName := input.Kubeconfigs[input.Env]
+
+	if kubeconfigName == nil {
+		return "", fmt.Errorf("No kubeconfig found for env %s", input.Env)
+	}
+
+	kubeconfig := fmt.Sprintf("%s%s", input.KubeDir, kubeconfigName)
+	buffer.WriteString(fmt.Sprintf("export KUBECONFIG=%s\n", kubeconfig))
+	buffer.WriteString("# Run this command to configure your shell:\n")
+	buffer.WriteString(fmt.Sprintf("# eval \"$(truss env -e %s)\"", input.Env))
+
+	return buffer.String(), nil
+}

--- a/truss/env_test.go
+++ b/truss/env_test.go
@@ -24,9 +24,7 @@ func TestEnv(t *testing.T) {
 			}
 			output, err := Env(input)
 			So(err, ShouldBeNil)
-			So(output, ShouldStartWith, "export KUBECONFIG=/home/test/.kube/kubeconfig-truss-nonprod-cmh")
-			So(output, ShouldContainSubstring, "# Run this command to configure your shell:")
-			So(output, ShouldContainSubstring, "# eval \"$(truss env -e edge-cmh)")
+			So(output.Kubeconfig, ShouldEqual, "/home/test/.kube/kubeconfig-truss-nonprod-cmh")
 		})
 
 		Convey("handles case when no kubeconfig found", func() {
@@ -36,8 +34,21 @@ func TestEnv(t *testing.T) {
 				KubeDir:     kubeDir,
 			}
 			output, err := Env(input)
-			So(output, ShouldBeEmpty)
+			So(output.Kubeconfig, ShouldBeEmpty)
 			So(err.Error(), ShouldEqual, "No kubeconfig found for env bogus")
 		})
+	})
+}
+
+func TestBashFormat(t *testing.T) {
+	Convey("formats Envs into bash command that can be eval'd", t, func() {
+		environmentVars := &EnvironmentVars{
+			Kubeconfig: "/home/test/.kube/kubeconfig-truss-nonprod-cmh",
+		}
+
+		output := environmentVars.BashFormat("edge-cmh")
+		So(output, ShouldStartWith, "export KUBECONFIG=/home/test/.kube/kubeconfig-truss-nonprod-cmh")
+		So(output, ShouldContainSubstring, "# Run this command to configure your shell:")
+		So(output, ShouldContainSubstring, "# eval \"$(truss env -e edge-cmh)")
 	})
 }

--- a/truss/env_test.go
+++ b/truss/env_test.go
@@ -1,0 +1,43 @@
+package truss
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestEnv(t *testing.T) {
+	Convey("Env", t, func() {
+		env := "edge-cmh"
+		kubeconfigs := map[string]interface{}{
+			"edge-cmh":    "kubeconfig-truss-nonprod-cmh",
+			"staging-cmh": "kubeconfig-truss-nonprod-cmh",
+			"staging-dub": "kubeconfig-truss-nonprod-dub",
+		}
+		kubeDir := "/home/test/.kube/"
+
+		Convey("when kubeconfig is found", func() {
+			input := &EnvInput{
+				Env:         env,
+				Kubeconfigs: kubeconfigs,
+				KubeDir:     kubeDir,
+			}
+			output, err := Env(input)
+			So(err, ShouldBeNil)
+			So(output, ShouldStartWith, "export KUBECONFIG=/home/test/.kube/kubeconfig-truss-nonprod-cmh")
+			So(output, ShouldContainSubstring, "# Run this command to configure your shell:")
+			So(output, ShouldContainSubstring, "# eval \"$(truss env -e edge-cmh)")
+		})
+
+		Convey("handles case when no kubeconfig found", func() {
+			input := &EnvInput{
+				Env:         "bogus",
+				Kubeconfigs: kubeconfigs,
+				KubeDir:     kubeDir,
+			}
+			output, err := Env(input)
+			So(output, ShouldBeEmpty)
+			So(err.Error(), ShouldEqual, "No kubeconfig found for env bogus")
+		})
+	})
+}


### PR DESCRIPTION
Usage:

```
$ truss env -e staging-cmh
export KUBECONFIG=/Users/jblanchard/.kube/kubeconfig-truss-nonprod-cmh
# Run this command to configure your shell:
# eval "$(truss env -e staging-cmh)"
```

Follow the instructions and eval it, then be on with your way:
```
$ eval "$(truss env -e staging-cmh)"
$ kubectl get namespaces
```