### PR TITLE
Add wrap command

### DIFF
--- a/cmd/wrap.go
+++ b/cmd/wrap.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/instructure-bridge/truss-cli/truss"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// wrapCmd represents the wrap command
+var wrapCmd = &cobra.Command{
+	Use: "wrap",
+	Long: `
+Sets KUBECONFIG and then executes the subcommand:
+
+	$ truss wrap -e edge-cmh -- printenv
+
+This allows you to do this:
+
+	$ truss wrap -e edge-cmh -- k9s
+`,
+	Short: "Wraps a subcommand with truss environment variables",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		env, err := cmd.Flags().GetString("env")
+		if err != nil {
+			return err
+		}
+		kubeconfigs := viper.GetStringMap("environments")
+		kubeDir, err := getKubeDir()
+		if err != nil {
+			return err
+		}
+
+		if len(args) == 0 {
+			cmd.Help()
+			os.Exit(0)
+		}
+
+		bin := args[0]
+		binargs := args[1:]
+
+		input := &truss.WrapInput{
+			Env:         env,
+			Kubeconfigs: kubeconfigs,
+			KubeDir:     kubeDir,
+			Stdout:      cmd.OutOrStdout(),
+			Stdin:       os.Stdin,
+			Stderr:      cmd.ErrOrStderr(),
+		}
+
+		err = truss.Wrap(input, bin, binargs...)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(wrapCmd)
+}

--- a/cmd/wrap_test.go
+++ b/cmd/wrap_test.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"github.com/spf13/viper"
+)
+
+func TestWrap(t *testing.T) {
+	Convey("wrap", t, func() {
+		viper.Reset()
+
+		Convey("runs subcommand", func() {
+			viper.Set("environments", map[string]interface{}{
+				"edge-cmh": "kubeconfig-truss-nonprod-cmh",
+			})
+			cmd := rootCmd
+			buff := bytes.NewBufferString("")
+			cmd.SetOut(buff)
+			cmd.SetArgs([]string{
+				"wrap",
+				"-e",
+				"edge-cmh",
+				"--",
+				"echo",
+				"hello",
+			})
+			cmd.Execute()
+			out, _ := ioutil.ReadAll(buff)
+			So(string(out), ShouldEqual, "hello\n")
+		})
+
+		Convey("shows subcommand errors", func() {
+			viper.Set("environments", map[string]interface{}{
+				"edge-cmh": "kubeconfig-truss-nonprod-cmh",
+			})
+			cmd := rootCmd
+			buff := bytes.NewBufferString("")
+			cmd.SetOut(buff)
+			errBuff := bytes.NewBufferString("")
+			cmd.SetErr(errBuff)
+			cmd.SetArgs([]string{
+				"wrap",
+				"-e",
+				"edge-cmh",
+				"--",
+				"ls",
+				"asdf",
+			})
+			cmd.Execute()
+			out, _ := ioutil.ReadAll(buff)
+			errOut, _ := ioutil.ReadAll(errBuff)
+			So(string(out), ShouldContainSubstring, "Error: exit status 1\n")
+			So(string(errOut), ShouldContainSubstring, "ls: asdf: No such file or directory")
+		})
+
+		Convey("shows usage if passed zero args ", func() {
+			viper.Set("environments", map[string]interface{}{
+				"edge-cmh": "kubeconfig-truss-nonprod-cmh",
+			})
+			cmd := rootCmd
+			buff := bytes.NewBufferString("")
+			cmd.SetOut(buff)
+			cmd.SetArgs([]string{
+				"wrap",
+			})
+			cmd.Execute()
+			out, _ := ioutil.ReadAll(buff)
+			So(string(out), ShouldContainSubstring, "Sets KUBECONFIG and then executes the subcommand")
+		})
+	})
+}

--- a/truss/wrap.go
+++ b/truss/wrap.go
@@ -1,0 +1,41 @@
+package truss
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+)
+
+// WrapInput input for Wrap
+type WrapInput struct {
+	Env         string
+	Kubeconfigs map[string]interface{}
+	KubeDir     string
+	Stdout      io.Writer
+	Stderr      io.Writer
+	Stdin       io.Reader
+}
+
+// Wrap exports relevant kubeconfig and runs command
+func Wrap(input *WrapInput, bin string, arg ...string) error {
+	cmd := exec.Command(bin, arg...)
+	cmd.Stdout = input.Stdout
+	cmd.Stdin = input.Stdin
+	cmd.Stderr = input.Stderr
+	envKubeconfig := input.Kubeconfigs[input.Env]
+	var kubeconfig string
+
+	if envKubeconfig != nil {
+		kubeconfigName := fmt.Sprintf("%s", envKubeconfig)
+		kubeconfig = fmt.Sprintf("%s%s", input.KubeDir, kubeconfigName)
+		cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfig)
+	}
+
+	err := cmd.Run()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/truss/wrap_test.go
+++ b/truss/wrap_test.go
@@ -1,0 +1,81 @@
+package truss
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestWrap(t *testing.T) {
+	Convey("Wrap", t, func() {
+		env := "edge-cmh"
+		kubeconfigs := map[string]interface{}{
+			"edge-cmh": "kubeconfig-truss-nonprod-cmh",
+		}
+		kubeDir := "/home/test/.kube/"
+
+		out := bytes.NewBufferString("")
+
+		Convey("runs subcommand", func() {
+			input := &WrapInput{
+				Env:         env,
+				Kubeconfigs: kubeconfigs,
+				KubeDir:     kubeDir,
+				Stdout:      out,
+				Stderr:      os.Stderr,
+				Stdin:       os.Stdin,
+			}
+
+			err := Wrap(input, "echo", "hello")
+			So(err, ShouldBeNil)
+			So(out.String(), ShouldContainSubstring, "hello")
+		})
+
+		Convey("runs subcommand when kubeconfig is not found", func() {
+			input := &WrapInput{
+				Env:         "no-env",
+				Kubeconfigs: kubeconfigs,
+				KubeDir:     kubeDir,
+				Stdout:      out,
+				Stderr:      os.Stderr,
+				Stdin:       os.Stdin,
+			}
+
+			err := Wrap(input, "echo", "hello")
+			So(err, ShouldBeNil)
+			So(out.String(), ShouldContainSubstring, "hello")
+		})
+
+		Convey("sets KUBECONFIG for the command", func() {
+			input := &WrapInput{
+				Env:         env,
+				Kubeconfigs: kubeconfigs,
+				KubeDir:     kubeDir,
+				Stdout:      out,
+				Stderr:      bytes.NewBufferString(""),
+				Stdin:       os.Stdin,
+			}
+			err := Wrap(input, "printenv")
+			So(err, ShouldBeNil)
+			So(out.String(), ShouldContainSubstring, "KUBECONFIG=/home/test/.kube/kubeconfig-truss-nonprod-cmh")
+		})
+
+		Convey("returns error and sends it to stderr", func() {
+			errOut := bytes.NewBufferString("")
+
+			input := &WrapInput{
+				Env:         env,
+				Kubeconfigs: kubeconfigs,
+				KubeDir:     kubeDir,
+				Stdout:      out,
+				Stderr:      errOut,
+				Stdin:       os.Stdin,
+			}
+			err := Wrap(input, "ls", "asdf")
+			So(err.Error(), ShouldEqual, "exit status 1")
+			So(errOut.String(), ShouldContainSubstring, "ls: asdf: No such file or directory")
+		})
+	})
+}


### PR DESCRIPTION
Usage:

```
$ truss wrap -e edge-cmh -- echo "hello"
hello
```
```
$ truss wrap -e edge-cmh -- printenv
...
KUBECONFIG=/Users/jblanchard/.kube/kubeconfig-truss-nonprod-cmh
...
```

This also works:

```
$ truss wrap -e edge-cmh -- k9s
```