### PR TITLE
Allows `secrets edit` to work without arguments

### DIFF
--- a/cmd/secretsEdit.go
+++ b/cmd/secretsEdit.go
@@ -31,8 +31,13 @@ var secretsEditCmd = &cobra.Command{
 			return nil
 		}
 
-		if editPush || prompter.YesNo("Push to environment "+args[0]+"?", false) {
-			return secretsPushCmd.RunE(cmd, args)
+		if editPush || prompter.YesNo("Push to environment "+ secret.Name +"?", false) {
+			if len(args) > 0 {
+				return secretsPushCmd.RunE(cmd, args)
+			} else {
+				new_args := []string{secret.Name}
+				return secretsPushCmd.RunE(cmd, new_args)
+			}
 		}
 		return nil
 	},

--- a/cmd/secretsEdit.go
+++ b/cmd/secretsEdit.go
@@ -35,8 +35,8 @@ var secretsEditCmd = &cobra.Command{
 			if len(args) > 0 {
 				return secretsPushCmd.RunE(cmd, args)
 			} else {
-				new_args := []string{secret.Name}
-				return secretsPushCmd.RunE(cmd, new_args)
+				newArgs := []string{secret.Name}
+				return secretsPushCmd.RunE(cmd, newArgs)
 			}
 		}
 		return nil


### PR DESCRIPTION
Fixes #29 

Previously, this would use `args[0]` to attempt to push the secrets, which could fail if the user provided the environment via prompt instead of the CLI arguments. This now constructs a new list of arguments to push if the CLI arguments were empty, using the name of the secret as the sole argument to the push command.