### PR TITLE
fix default env if one isn't provided

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -29,13 +29,15 @@ func getKubeconfigName() (string, error) {
 }
 
 func getKubeconfig() (string, error) {
-	var kubeconfigDir string
-	kubeconfigDir, err := getKubeDir()
+	kubeconfig, err := getKubeconfigName()
 	if err != nil {
 		return "", err
 	}
+	if kubeconfig == "" {
+		return "", nil
+	}
 
-	kubeconfig, err := getKubeconfigName()
+	kubeconfigDir, err := getKubeDir()
 	if err != nil {
 		return "", err
 	}

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -23,6 +23,16 @@ func TestConfig(t *testing.T) {
 	})
 
 	Convey("getKubeconfig", t, func() {
+		Convey("defaults to empty string", func() {
+			viper.Set("environments", map[string]string{})
+
+			rootCmd.SetArgs([]string{})
+			rootCmd.PersistentFlags().Set("env", "")
+			kubeconfig, err := getKubeconfig()
+			So(err, ShouldBeNil)
+			So(kubeconfig, ShouldBeEmpty)
+		})
+
 		Convey("gets kubeconfig full path from env", func() {
 			viper.Set("environments", map[string]string{
 				"my-env": "my-kube",


### PR DESCRIPTION
test plan:
  • go run . kubectl get ns
  • connects to current kube ctx
  • go run . kubectl -e nonprod-dub get ns
  • connects to current specified