### PR TITLE
Error truss wrap when -e is not provided or malformed refs CC-677

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -21,13 +21,17 @@ func getKubeconfigName() (string, error) {
 	environments := viper.GetStringMapString("environments")
 	kubeconfig := environments[env]
 	if kubeconfig == "" {
-		var keys []string
-		for k := range environments {
-			keys = append(keys, k)
-		}
-		return "", fmt.Errorf("unknown env %v. Options: %v", env, keys)
+		return "", fmt.Errorf("unknown env %v. Options: %v", env, getEnvironmentKeys(environments))
 	}
 	return kubeconfig, nil
+}
+
+func getEnvironmentKeys(environments map[string]string) []string {
+	var keys []string
+	for k := range environments {
+		keys = append(keys, k)
+	}
+	return keys
 }
 
 func getKubeconfig() (string, error) {

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -83,4 +83,17 @@ func TestConfig(t *testing.T) {
 			So(must(envClusterRoleArn()), ShouldEqual, "arn:aws:iam::127178877223:role/xacct/ops-admin")
 		})
 	})
+
+	Convey("getEnvironmentKeys", t, func() {
+		Convey("returns available environment keys", func() {
+			environments := map[string]string{
+				"dev":  "dev-kube",
+				"prod": "prod-kube",
+			}
+
+			keys := getEnvironmentKeys(environments)
+
+			So(keys, ShouldResemble, []string{"dev", "prod"})
+		})
+	})
 }

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"sort"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -92,6 +93,7 @@ func TestConfig(t *testing.T) {
 			}
 
 			keys := getEnvironmentKeys(environments)
+			sort.Strings(keys)
 
 			So(keys, ShouldResemble, []string{"dev", "prod"})
 		})

--- a/cmd/wrap.go
+++ b/cmd/wrap.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/instructure-bridge/truss-cli/truss"
@@ -26,10 +27,10 @@ This allows you to do this:
 		if err != nil {
 			return err
 		}
-		kubeconfigs := viper.GetStringMap("environments")
-		kubeDir, err := getKubeDir()
-		if err != nil {
-			return err
+		environments := viper.GetStringMapString("environments")
+
+		if env == "" {
+			return fmt.Errorf("-e flag is required. Options: %v", getEnvironmentKeys(environments))
 		}
 
 		if len(args) == 0 {
@@ -40,13 +41,17 @@ This allows you to do this:
 		bin := args[0]
 		binargs := args[1:]
 
+		kubeconfig, err := getKubeconfig()
+
+		if err != nil {
+			return err
+		}
+
 		input := &truss.WrapInput{
-			Env:         env,
-			Kubeconfigs: kubeconfigs,
-			KubeDir:     kubeDir,
-			Stdout:      cmd.OutOrStdout(),
-			Stdin:       os.Stdin,
-			Stderr:      cmd.ErrOrStderr(),
+			Kubeconfig: kubeconfig,
+			Stdout:     cmd.OutOrStdout(),
+			Stdin:      os.Stdin,
+			Stderr:     cmd.ErrOrStderr(),
 		}
 
 		err = truss.Wrap(input, bin, binargs...)

--- a/cmd/wrap.go
+++ b/cmd/wrap.go
@@ -1,12 +1,10 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/instructure-bridge/truss-cli/truss"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // wrapCmd represents the wrap command
@@ -23,16 +21,6 @@ This allows you to do this:
 `,
 	Short: "Wraps a subcommand with truss environment variables",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		env, err := cmd.Flags().GetString("env")
-		if err != nil {
-			return err
-		}
-		environments := viper.GetStringMapString("environments")
-
-		if env == "" {
-			return fmt.Errorf("-e flag is required. Options: %v", getEnvironmentKeys(environments))
-		}
-
 		if len(args) == 0 {
 			cmd.Help()
 			os.Exit(0)

--- a/cmd/wrap_test.go
+++ b/cmd/wrap_test.go
@@ -14,27 +14,6 @@ func TestWrap(t *testing.T) {
 		viper.Reset()
 		viper.Set("kubeconfigfiles.directory", "/tmp/")
 
-		Convey("returns error when no -e flag is set", func() {
-			viper.Set("environments", map[string]interface{}{
-				"edge-cmh": "kubeconfig-truss-nonprod-cmh",
-			})
-
-			cmd := rootCmd
-			viper.BindPFlag("TRUSS_ENV", cmd.PersistentFlags().Lookup("env"))
-			buff := bytes.NewBufferString("")
-			cmd.SetOut(buff)
-			cmd.SetArgs([]string{
-				"wrap",
-				"-e",
-				"", // Simulating passing in no flag, here. I think persistent flag state is leaking between tests. TODO: Figure out a better integration testing strategy
-				"--",
-				"printenv",
-			})
-			cmd.Execute()
-			out, _ := ioutil.ReadAll(buff)
-			So(string(out), ShouldContainSubstring, "-e flag is required. Options: [edge-cmh]")
-		})
-
 		Convey("returns error when -e flag is set to an invalid environment", func() {
 			viper.Set("environments", map[string]interface{}{
 				"edge-cmh": "kubeconfig-truss-nonprod-cmh",

--- a/cmd/wrap_test.go
+++ b/cmd/wrap_test.go
@@ -25,6 +25,8 @@ func TestWrap(t *testing.T) {
 			cmd.SetOut(buff)
 			cmd.SetArgs([]string{
 				"wrap",
+				"-e",
+				"", // Simulating passing in no flag, here. I think persistent flag state is leaking between tests. TODO: Figure out a better integration testing strategy
 				"--",
 				"printenv",
 			})

--- a/cmd/wrap_test.go
+++ b/cmd/wrap_test.go
@@ -1,12 +1,78 @@
 package cmd
 
 import (
+	"bytes"
+	"io/ioutil"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/spf13/viper"
 )
 
 func TestWrap(t *testing.T) {
-	// Any tests we can get?
-	Convey("wrap", t, nil)
+	Convey("wrap", t, func() {
+		viper.Reset()
+		viper.Set("kubeconfigfiles.directory", "/tmp/")
+
+		Convey("returns error when no -e flag is set", func() {
+			viper.Set("environments", map[string]interface{}{
+				"edge-cmh": "kubeconfig-truss-nonprod-cmh",
+			})
+
+			cmd := rootCmd
+			viper.BindPFlag("TRUSS_ENV", cmd.PersistentFlags().Lookup("env"))
+			buff := bytes.NewBufferString("")
+			cmd.SetOut(buff)
+			cmd.SetArgs([]string{
+				"wrap",
+				"--",
+				"printenv",
+			})
+			cmd.Execute()
+			out, _ := ioutil.ReadAll(buff)
+			So(string(out), ShouldContainSubstring, "-e flag is required. Options: [edge-cmh]")
+		})
+
+		Convey("returns error when -e flag is set to an invalid environment", func() {
+			viper.Set("environments", map[string]interface{}{
+				"edge-cmh": "kubeconfig-truss-nonprod-cmh",
+			})
+
+			cmd := rootCmd
+			viper.BindPFlag("TRUSS_ENV", cmd.PersistentFlags().Lookup("env"))
+			buff := bytes.NewBufferString("")
+			cmd.SetOut(buff)
+			cmd.SetArgs([]string{
+				"wrap",
+				"-e",
+				"noenv",
+				"--",
+				"printenv",
+			})
+			cmd.Execute()
+			out, _ := ioutil.ReadAll(buff)
+			So(string(out), ShouldContainSubstring, "unknown env noenv")
+		})
+
+		Convey("sets env from kubeconfings and runs command", func() {
+			viper.Set("environments", map[string]interface{}{
+				"edge-cmh": "kubeconfig-truss-nonprod-cmh",
+			})
+
+			cmd := rootCmd
+			viper.BindPFlag("TRUSS_ENV", cmd.PersistentFlags().Lookup("env"))
+			buff := bytes.NewBufferString("")
+			cmd.SetOut(buff)
+			cmd.SetArgs([]string{
+				"wrap",
+				"-e",
+				"edge-cmh",
+				"--",
+				"printenv",
+			})
+			cmd.Execute()
+			out, _ := ioutil.ReadAll(buff)
+			So(string(out), ShouldContainSubstring, "KUBECONFIG=/tmp/kubeconfig-truss-nonprod-cmh")
+		})
+	})
 }

--- a/truss/wrap.go
+++ b/truss/wrap.go
@@ -1,21 +1,18 @@
 package truss
 
 import (
-	"fmt"
+	"errors"
 	"io"
 	"os"
 	"os/exec"
-	"path/filepath"
 )
 
 // WrapInput input for Wrap
 type WrapInput struct {
-	Env         string
-	Kubeconfigs map[string]interface{}
-	KubeDir     string
-	Stdout      io.Writer
-	Stderr      io.Writer
-	Stdin       io.Reader
+	Kubeconfig string
+	Stdout     io.Writer
+	Stderr     io.Writer
+	Stdin      io.Reader
 }
 
 // Wrap exports relevant kubeconfig and runs command
@@ -24,15 +21,12 @@ func Wrap(input *WrapInput, bin string, arg ...string) error {
 	cmd.Stdout = input.Stdout
 	cmd.Stdin = input.Stdin
 	cmd.Stderr = input.Stderr
-	envKubeconfig := input.Kubeconfigs[input.Env]
-	var kubeconfig string
 
-	if envKubeconfig != nil {
-		kubeconfigName := fmt.Sprintf("%s", envKubeconfig)
-		kubeconfig = filepath.Join(input.KubeDir, kubeconfigName)
-		cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfig)
+	if input.Kubeconfig == "" {
+		return errors.New("Kubeconfig is required")
 	}
 
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+input.Kubeconfig)
 	err := cmd.Run()
 	if err != nil {
 		return err

--- a/truss/wrap.go
+++ b/truss/wrap.go
@@ -1,7 +1,6 @@
 package truss
 
 import (
-	"errors"
 	"io"
 	"os"
 	"os/exec"
@@ -22,11 +21,10 @@ func Wrap(input *WrapInput, bin string, arg ...string) error {
 	cmd.Stdin = input.Stdin
 	cmd.Stderr = input.Stderr
 
-	if input.Kubeconfig == "" {
-		return errors.New("Kubeconfig is required")
+	if input.Kubeconfig != "" {
+		cmd.Env = append(os.Environ(), "KUBECONFIG="+input.Kubeconfig)
 	}
 
-	cmd.Env = append(os.Environ(), "KUBECONFIG="+input.Kubeconfig)
 	err := cmd.Run()
 	if err != nil {
 		return err

--- a/truss/wrap_test.go
+++ b/truss/wrap_test.go
@@ -25,17 +25,6 @@ func TestWrap(t *testing.T) {
 			So(out.String(), ShouldContainSubstring, "hello")
 		})
 
-		Convey("returns error when there's no kubeconfig", func() {
-			input := &WrapInput{
-				Stdout: out,
-				Stderr: os.Stderr,
-				Stdin:  os.Stdin,
-			}
-
-			err := Wrap(input, "echo", "hello")
-			So(err.Error(), ShouldEqual, "Kubeconfig is required")
-		})
-
 		Convey("sets KUBECONFIG for the command", func() {
 			input := &WrapInput{
 				Kubeconfig: "/kube/config",

--- a/truss/wrap_test.go
+++ b/truss/wrap_test.go
@@ -10,22 +10,14 @@ import (
 
 func TestWrap(t *testing.T) {
 	Convey("Wrap", t, func() {
-		env := "edge-cmh"
-		kubeconfigs := map[string]interface{}{
-			"edge-cmh": "kubeconfig-truss-nonprod-cmh",
-		}
-		kubeDir := "/home/test/.kube/"
-
 		out := bytes.NewBufferString("")
 
 		Convey("runs subcommand", func() {
 			input := &WrapInput{
-				Env:         env,
-				Kubeconfigs: kubeconfigs,
-				KubeDir:     kubeDir,
-				Stdout:      out,
-				Stderr:      os.Stderr,
-				Stdin:       os.Stdin,
+				Kubeconfig: "/kube/config",
+				Stdout:     out,
+				Stderr:     os.Stderr,
+				Stdin:      os.Stdin,
 			}
 
 			err := Wrap(input, "echo", "hello")
@@ -33,45 +25,37 @@ func TestWrap(t *testing.T) {
 			So(out.String(), ShouldContainSubstring, "hello")
 		})
 
-		Convey("runs subcommand when kubeconfig is not found", func() {
+		Convey("returns error when there's no kubeconfig", func() {
 			input := &WrapInput{
-				Env:         "no-env",
-				Kubeconfigs: kubeconfigs,
-				KubeDir:     kubeDir,
-				Stdout:      out,
-				Stderr:      os.Stderr,
-				Stdin:       os.Stdin,
+				Stdout: out,
+				Stderr: os.Stderr,
+				Stdin:  os.Stdin,
 			}
 
 			err := Wrap(input, "echo", "hello")
-			So(err, ShouldBeNil)
-			So(out.String(), ShouldContainSubstring, "hello")
+			So(err.Error(), ShouldEqual, "Kubeconfig is required")
 		})
 
 		Convey("sets KUBECONFIG for the command", func() {
 			input := &WrapInput{
-				Env:         env,
-				Kubeconfigs: kubeconfigs,
-				KubeDir:     kubeDir,
-				Stdout:      out,
-				Stderr:      bytes.NewBufferString(""),
-				Stdin:       os.Stdin,
+				Kubeconfig: "/kube/config",
+				Stdout:     out,
+				Stderr:     bytes.NewBufferString(""),
+				Stdin:      os.Stdin,
 			}
 			err := Wrap(input, "printenv")
 			So(err, ShouldBeNil)
-			So(out.String(), ShouldContainSubstring, "KUBECONFIG=/home/test/.kube/kubeconfig-truss-nonprod-cmh")
+			So(out.String(), ShouldContainSubstring, "KUBECONFIG=/kube/config")
 		})
 
 		Convey("returns error and sends it to stderr", func() {
 			errOut := bytes.NewBufferString("")
 
 			input := &WrapInput{
-				Env:         env,
-				Kubeconfigs: kubeconfigs,
-				KubeDir:     kubeDir,
-				Stdout:      out,
-				Stderr:      errOut,
-				Stdin:       os.Stdin,
+				Kubeconfig: "/kube/config",
+				Stdout:     out,
+				Stderr:     errOut,
+				Stdin:      os.Stdin,
 			}
 			err := Wrap(input, "ls", "asdf")
 			So(err.Error(), ShouldContainSubstring, "exit status")


### PR DESCRIPTION
~Implements the following behavior:~ See latest comment

1. ~`truss wrap -- printenv` - returns error because it's missing the `-e` flag~
2. ~`truss wrap -e bogus -- printenv` - returns error because `bogus` is not a valid environment in .truss.yaml~
3. ~`truss wrap -e nonprod-cmh -- printenv` - works and sets `KUBECONFIG` to the value for `nonprod-cmb` in truss.yaml~

The error messages should print out the available environments so you don't have to go hunting for them.