### PR TITLE
Case conversion in template parameters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-kv v0.5.6
 	github.com/hashicorp/vault/api v1.0.5-0.20200717191844-f687267c8086
 	github.com/hashicorp/vault/sdk v0.1.14-0.20200916223652-9510adcb9ad1
+	github.com/iancoleman/strcase v0.1.2
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -584,6 +584,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKe
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huaweicloud/golangsdk v0.0.0-20200304081349-45ec0797f2a4/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
+github.com/iancoleman/strcase v0.1.2 h1:gnomlvw9tnV3ITTAxzKSgTF+8kFWcU/f+TgttpXGz1U=
+github.com/iancoleman/strcase v0.1.2/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/truss/bootstrapParameter.go
+++ b/truss/bootstrapParameter.go
@@ -1,0 +1,54 @@
+package truss
+
+import (
+	"strings"
+
+	"github.com/iancoleman/strcase"
+)
+
+// BootstrapParameter - struct to handle types and case conversions
+type BootstrapParameter struct {
+	Type  string
+	Value string
+
+	PascalCase string
+	CamelCase  string
+	KebabCase  string
+	SnakeCase  string
+	FlatCase   string
+}
+
+// NewBootstrapParameter - create a bootstrap parameter with the type string
+func NewBootstrapParameter(value string) *BootstrapParameter {
+	param := &BootstrapParameter{Type: "string", Value: value}
+	param.generateCases()
+
+	return param
+}
+
+func (c *BootstrapParameter) String() string {
+	return c.Value
+}
+
+func (c *BootstrapParameter) generateCases() {
+	c.PascalCase = strcase.ToCamel(c.Value)
+	c.CamelCase = strcase.ToLowerCamel(c.Value)
+	c.KebabCase = strcase.ToKebab(c.Value)
+	c.SnakeCase = strcase.ToSnake(c.Value)
+	c.FlatCase = strings.ReplaceAll(strcase.ToSnake(c.Value), "_", "")
+}
+
+// NewBootstrapParameterBool - create a bootstrap parameter with the type bool
+func NewBootstrapParameterBool(value bool) *BootstrapParameter {
+	var v string
+	if value {
+		v = "true"
+	} else {
+		v = "false"
+	}
+
+	param := &BootstrapParameter{Type: "bool", Value: v}
+	param.generateCases()
+
+	return param
+}

--- a/truss/bootstrapParameter_test.go
+++ b/truss/bootstrapParameter_test.go
@@ -1,0 +1,43 @@
+package truss
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestBootstrapParameter(t *testing.T) {
+	Convey("BootstrapParameter", t, func() {
+		Convey("Strings are given the type `string`", func() {
+			p := NewBootstrapParameter("anything")
+
+			So(p.Type, ShouldEqual, "string")
+		})
+
+		Convey("Booleans are given the type `bool` and return a string", func() {
+			p := NewBootstrapParameterBool(true)
+
+			So(p.Type, ShouldEqual, "bool")
+			So(p.String(), ShouldEqual, "true")
+		})
+
+		Convey("Simple case conversions work", func() {
+			inputs := []string{"simple-test", "simpleTest", "SimpleTest", "simple_test"}
+
+			for _, input := range inputs {
+				p := NewBootstrapParameter(input)
+
+				So(p.CamelCase, ShouldEqual, "simpleTest")
+				So(p.PascalCase, ShouldEqual, "SimpleTest")
+				So(p.KebabCase, ShouldEqual, "simple-test")
+				So(p.SnakeCase, ShouldEqual, "simple_test")
+				So(p.FlatCase, ShouldEqual, "simpletest")
+			}
+		})
+
+		Convey("Even bools can be converted (useful for eg. Python)", func() {
+			So(NewBootstrapParameterBool(true).CamelCase, ShouldEqual, "True")
+			So(NewBootstrapParameterBool(false).CamelCase, ShouldEqual, "False")
+		})
+	})
+}

--- a/truss/bootstrapParameter_test.go
+++ b/truss/bootstrapParameter_test.go
@@ -36,8 +36,8 @@ func TestBootstrapParameter(t *testing.T) {
 		})
 
 		Convey("Even bools can be converted (useful for eg. Python)", func() {
-			So(NewBootstrapParameterBool(true).CamelCase, ShouldEqual, "True")
-			So(NewBootstrapParameterBool(false).CamelCase, ShouldEqual, "False")
+			So(NewBootstrapParameterBool(true).PascalCase, ShouldEqual, "True")
+			So(NewBootstrapParameterBool(false).PascalCase, ShouldEqual, "False")
 		})
 	})
 }


### PR DESCRIPTION
Case conversion in template parameters

This is my idea to add simple case conversions to templates without
rewriting (and complicating) the already existing template. After
this is merged, we could still use the variables as before:

```
{{ Params.name }}
```

but the case conversions going to be available using the fields
in `BootstrapParameter`:

```
{{ Params.name.CamelCase }}
```

The currently supported cases are:
- `.PascalCase` &rarr; `PascalCase` (eg. for class names)
- `.CamelCase` &rarr; `camelCase` (eg. for controller methods)
- `.KebabCase` &rarr; `kebab-case` (eg. for URL slugs)
- `.SnakeCase` &rarr; `snake_case` (eg. for Shell scripts)
- `.FlatCase` &rarr; `flatcase` (eg. for Java package names)
