### PR TITLE
Configuring AWS STS Region

### DIFF
--- a/cmd/vault.go
+++ b/cmd/vault.go
@@ -31,15 +31,18 @@ As it will port-forward to the service and call aws auth`,
 func getVaultAuth() truss.VaultAuth {
 	vaultRole := viper.GetString("vault.auth.aws.vaultrole")
 	awsRole := viper.GetString("vault.auth.aws.awsrole")
+	awsRegion := viper.GetString("vault.auth.aws.awsregion")
 
 	if vaultRole == "" || awsRole == "" {
 		return nil
 	}
 
-	return truss.VaultAuthAWS(vaultRole, awsRole)
+	return truss.VaultAuthAWS(vaultRole, awsRole, awsRegion)
 }
 
 func init() {
 	rootCmd.AddCommand(vaultCmd)
 	vaultCmd.Flags().SetInterspersed(false)
+
+	viper.SetDefault("vault.auth.aws.awsregion", "us-east-1")
 }

--- a/integration_tests/secretsManager_test.go
+++ b/integration_tests/secretsManager_test.go
@@ -40,7 +40,7 @@ secrets:
 		awsrole, ok := os.LookupEnv("TEST_AWS_ROLE")
 		if ok {
 			vaultrole := os.Getenv("TEST_VAULT_ROLE")
-			auth = truss.VaultAuthAWS(vaultrole, awsrole)
+			auth = truss.VaultAuthAWS(vaultrole, awsrole, "us-east-1")
 		}
 		sm, err := truss.NewSecretsManager(secretsPath, "", auth)
 		So(err, ShouldBeNil)

--- a/integration_tests/vault_test.go
+++ b/integration_tests/vault_test.go
@@ -14,7 +14,7 @@ func TestVault(t *testing.T) {
 		awsrole, ok := os.LookupEnv("TEST_AWS_ROLE")
 		if ok {
 			vaultrole := os.Getenv("TEST_VAULT_ROLE")
-			auth = truss.VaultAuthAWS(vaultrole, awsrole)
+			auth = truss.VaultAuthAWS(vaultrole, awsrole, "us-east-1")
 		}
 		vault := truss.Vault("", auth)
 

--- a/truss/secretFileConfig.go
+++ b/truss/secretFileConfig.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"strings"
 
 	"gopkg.in/yaml.v2"
 )
@@ -74,9 +75,11 @@ func (s SecretFileConfig) getDecryptedFromDisk(vault *VaultCmd, transitKeyName s
 	}
 
 	decrypted, err := vault.Decrypt(transitKeyName, encrypted)
-	if err != nil {
+	if err != nil && strings.Contains(err.Error(), "invalid ciphertext") {
 		// if we fail to decrypt, might not be encypted
 		return encrypted, nil
+	} else if err != nil {
+		return nil, err
 	}
 
 	return decrypted, nil

--- a/truss/vault_auth_aws.go
+++ b/truss/vault_auth_aws.go
@@ -11,13 +11,15 @@ import (
 type vaultAuthAWS struct {
 	vaultRole string
 	awsRole   string
+	awsRegion string
 }
 
 // VaultAuthAWS vault auth
-func VaultAuthAWS(vaultRole, awsRole string) VaultAuth {
+func VaultAuthAWS(vaultRole, awsRole, awsRegion string) VaultAuth {
 	return &vaultAuthAWS{
 		vaultRole: vaultRole,
 		awsRole:   awsRole,
+		awsRegion: awsRegion,
 	}
 }
 
@@ -34,7 +36,7 @@ func (auth *vaultAuthAWS) LoadCreds() (interface{}, error) {
 		return nil, err
 	}
 
-	return awsauth.GenerateLoginData(creds, "", "")
+	return awsauth.GenerateLoginData(creds, "", auth.awsRegion)
 }
 
 // Login for VaultAuth interface


### PR DESCRIPTION
The current assumption is that Vault's AWS Provider is currently configured to use the global STS endpoint, aka us-east-1. Since some users have their AWS CLI configured to use other regions by default via `~/.aws/config`, this commit allows us to be more explicit on the STS requests for Vault.