### PR TITLE
[CC-700] Make goreleases update the new tap

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,14 +35,14 @@ brews:
     homepage: https://github.com/instructure-bridge/truss-cli
     github:
       owner: instructure-bridge
-      name: homebrew-truss-cli
+      name: homebrew-tap
     folder: Formula
     dependencies:
       - name: kubectl
       - name: vault
       - name: sshuttle
     test: |
-      system bin/"truss", "help"
+      system "bin/truss", "help"
     install: |
       system "cp", "truss-cli", "truss"
       bin.install "truss"

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ vault:
 
 ### Mac Homebrew
 
+Grab yourself a [personal access token](https://github.com/settings/tokens/new?scopes=repo&description=Homebrew%20for%20Bridge%20VPN%20CLI). Then...
+
 ```sh
 brew install instructure-bridge/truss-cli/truss-cli
 ```


### PR DESCRIPTION
The tap has changed to `instructure-bridge/homebrew-tap`, so changing it here as well