### PR TITLE
Minor changes as part of the learning curve

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,7 +33,7 @@ brews:
     name: truss-cli
     description: CLI to help manage many k8s clusters
     homepage: https://github.com/instructure-bridge/truss-cli
-    github:
+    tap:
       owner: instructure-bridge
       name: homebrew-tap
     folder: Formula

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,7 +39,7 @@ brews:
     folder: Formula
     dependencies:
       - name: kubectl
-      - name: vault
+      - name: hashicorp/tap/vault
       - name: sshuttle
     test: |
       system "bin/truss", "help"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ vault:
 
 ### Mac / Linux Homebrew
 
-We use a own tap, take a look at [Bridge Homebrew Tap] (https://github.com/instructure-bridge/homebrew-tap) to see on how to use it.
+We use a own tap, take a look at [Bridge Homebrew Tap](https://github.com/instructure-bridge/homebrew-tap) to see on how to use it.
 
 ### GO
 

--- a/README.md
+++ b/README.md
@@ -35,13 +35,9 @@ vault:
 
 ## Install
 
-### Mac Homebrew
+### Mac / Linux Homebrew
 
-Grab yourself a [personal access token](https://github.com/settings/tokens/new?scopes=repo&description=Homebrew%20for%20Bridge%20VPN%20CLI). Then...
-
-```sh
-brew install instructure-bridge/truss-cli/truss-cli
-```
+We use a own tap, take a look at [Bridge Homebrew Tap] (https://github.com/instructure-bridge/homebrew-tap) to see on how to use it.
 
 ### GO
 

--- a/cmd/getKubeconfig.go
+++ b/cmd/getKubeconfig.go
@@ -25,15 +25,18 @@ kubeconfigfiles:
 		}
 
 		s3bucket := viper.GetString("kubeconfigfiles.s3.bucket")
-		if s3bucket != "" {
-			awsrole := viper.GetString("kubeconfigfiles.s3.awsrole")
-			region := viper.GetString("kubeconfigfiles.s3.region")
-			if region == "" {
-				return errors.New("s3 config must have region")
+		if s3bucket == "" {
+			if viper.ConfigFileUsed() == "" {
+				return errors.New("No global config file found")
 			}
-			return truss.GetKubeconfigS3(awsrole, s3bucket, dest, region).Fetch()
+			return errors.New(viper.ConfigFileUsed() + " does not contain a valid 'kubeconfigfiles'")
 		}
-		return nil
+		awsrole := viper.GetString("kubeconfigfiles.s3.awsrole")
+		region := viper.GetString("kubeconfigfiles.s3.region")
+		if region == "" {
+			return errors.New("s3 config must have region")
+		}
+		return truss.GetKubeconfigS3(awsrole, s3bucket, dest, region).Fetch()
 	},
 }
 

--- a/cmd/getKubeconfig_test.go
+++ b/cmd/getKubeconfig_test.go
@@ -15,7 +15,8 @@ func TestGetKubeconfig(t *testing.T) {
 
 		Convey("runs no errors", func() {
 			err := getKubeconfigCmd.RunE(c, []string{})
-			So(err, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "No global config file found")
 		})
 
 		Convey("s3 configured", func() {

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/instructure-bridge/truss-cli/truss"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -18,7 +20,12 @@ dependencies:
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		dependencies := viper.GetStringSlice("dependencies")
-		return truss.Setup(&dependencies)
+
+		err := truss.Setup(&dependencies)
+		if err == nil {
+			fmt.Println("No problems detected")
+		}
+		return err
 	},
 }
 

--- a/truss/getKubeconfigS3.go
+++ b/truss/getKubeconfigS3.go
@@ -33,7 +33,7 @@ func GetKubeconfigS3(awsRole string, bucket string, dest string, region string) 
 
 // Fetch kubeconfigs
 func (config *GetKubeconfigS3Cmd) Fetch() error {
-	log.Infoln("Fetching kubeconfig from s3")
+	log.Infoln("Fetching kubeconfig from s3 to " + config.dest)
 
 	sess, _ := session.NewSession(&aws.Config{
 		Region: aws.String(config.region)},


### PR DESCRIPTION
As my project for Hackweek I decided that it is time to learn a new language for me and decided to take a look at **go**. truss-cli was my chosen project with the major advantage that it might also teach me a lot about  truss itself and what it actually does. The result of my digging is here:

- while trying to pull global config from s3 I used the wrong password with the result that the already existing config was empty now. First commit changes the code so that it only will be replaced if successful
- if you run getKubeconfig and the configuration in the global config is wrong the cmd exists silently. The second commit adds an error message for this
- the cmd setup only indicated errors. Third commit adds a 'all fine'
- goreleaser had a deprecation warning in the console. Fourth commit updates the config
- the brew install instructions on the readme page was outdated. Now it links to the Bridge Homebrew tap page
- the current tap dependencies did not allow for installing on a linux OS due to dependencies of the used _vault_ Formula. Changing it to the _hashicorp/tap/vault_ Formula seems to solve that
- the last commit is the update of a test I overlooked



