### PR TITLE
Give PodDisruptionBudget template a real name

### DIFF
--- a/bootstrap-templates/default/modules/{{ .Params.name }}-{{ .Params.role }}/kustomize/podDisruptionBudget.yaml
+++ b/bootstrap-templates/default/modules/{{ .Params.name }}-{{ .Params.role }}/kustomize/podDisruptionBudget.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: pdb
+  name: {{ .Params.name }}-{{ .Params.role }}
 spec:
   # How many pods can Kubernetes make unavailable during cluster upgrades?
   maxUnavailable: 1


### PR DESCRIPTION
I've run into this a couple times now since multiple Practice services share a namespace.