### PR TITLE
Add ISTIO_ENABLED env var if istio flag is true

### DIFF
--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -108,6 +108,10 @@ func buildShellKubectlArgs(podName string, image string, istioEnabled bool, serv
 	// Adding a label so we can easily find and clean these up later
 	kubectlArgs = append(kubectlArgs, "--labels=truss.bridgeops.sh/shell=true")
 
+	if istioEnabled {
+		kubectlArgs = append(kubectlArgs, "--env=ISTIO_ENABLED=true")
+	}
+
 	// Here we are overriding the following in the Pod spec:
 	//   * name/generateName to give the pod a unique name
 	//   * annotations to enable/disable Istio injection


### PR DESCRIPTION
This should work properly in most cases with recent changes to
https://github.com/psi/toolbox

If you launch a Pod in a non-Istio namespace without specifying
`--istio=false`, you'll see errors when you exit the shell about
not being able to shutdown Istio, but the container will still
exit cleanly and delete the pod.