### PR TITLE
Rename the build binary to truss and fix the help docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.test
 
 # Binary
+/bin/truss
 /truss-cli
 
 # Output of the go coverage tool, specifically when used with LiteIDE

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,16 +1,13 @@
-# This is an example goreleaser.yaml file with some sane defaults.
-# Make sure to check the documentation at http://goreleaser.com
 before:
   hooks:
-    # You may remove this if you don't use go modules.
     - go mod download
-    # you may remove this if you don't need go generate
     - go generate ./...
 builds:
 - env:
   - CGO_ENABLED=0
   ldflags:
     - -X github.com/instructure-bridge/truss-cli/cmd.Version={{.Version}}
+  binary: truss
 archives:
 - replacements:
     darwin: Darwin
@@ -44,5 +41,4 @@ brews:
     test: |
       system "bin/truss", "help"
     install: |
-      system "cp", "truss-cli", "truss"
       bin.install "truss"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,7 +16,7 @@ var Version = "development"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:     "truss-cli",
+	Use:     "truss",
 	Short:   "A CLI for use with Bridge Truss",
 	Version: Version,
 	// Long: `TODO`,

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -29,7 +29,7 @@ func TestExecute(t *testing.T) {
 			cmd.Env = append(os.Environ(), "RUN_EXECUTE=1")
 			err := cmd.Run()
 			if e, ok := err.(*exec.ExitError); ok && !e.Success() {
-				So(stderr.String(), ShouldContainSubstring, "Error: unknown command \"foo\" for \"truss-cli\"")
+				So(stderr.String(), ShouldContainSubstring, "Error: unknown command \"foo\" for \"truss\"")
 				return
 			}
 			t.Fatalf("process ran with err %v, want exit status 1", err)
@@ -49,7 +49,7 @@ func TestRootCommand(t *testing.T) {
 			rootCmd.SetArgs([]string{"foo"})
 			err := rootCmd.Execute()
 			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldContainSubstring, "unknown command \"foo\" for \"truss-cli\"")
+			So(err.Error(), ShouldContainSubstring, "unknown command \"foo\" for \"truss\"")
 		})
 	})
 }


### PR DESCRIPTION
to match the end-result installed by homebrew.
